### PR TITLE
Changes `processors` to `const` and improves tests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,19 +9,15 @@ const defaultProcessors = {
 };
 
 module.exports = function app(themeYaml, format, config = {}) {
-  let processors = defaultProcessors;
-  if (config.processors) {
-    processors = Object.assign({}, config.processors, defaultProcessors);
-  }
+  const processors = Object.assign({}, config.processors || {}, defaultProcessors);
 
   if (!processors[format]) {
     throw new Error(`Missing processors for "${format}" format`);
   }
 
   try {
-    const processor = processors[format];
     const jsonTheme = yaml.safeLoad(themeYaml);
-    return processor.compile(jsonTheme, config.prefix ? config.prefix : '');
+    return processors[format].compile(jsonTheme, config.prefix ? config.prefix : '');
   } catch (error) {
     console.warn(`Failed to process theme with ${format} format. Reason:`);
     console.warn(error);

--- a/tests/specs/__snapshots__/app.spec.js.snap
+++ b/tests/specs/__snapshots__/app.spec.js.snap
@@ -19,3 +19,7 @@ Array [
   "$tx-do-some-string: aaa;",
 ]
 `;
+
+exports[`App should return null in case of error in processing JS 1`] = `null`;
+
+exports[`App should return null in case of error in processing yaml 1`] = `null`;

--- a/tests/specs/app.spec.js
+++ b/tests/specs/app.spec.js
@@ -1,5 +1,6 @@
 const app = require('../../src/app.js');
 const yaml = require('js-yaml');
+const js = require('../../src/processors/js');
 let doc;
 
 describe('App', () => {
@@ -24,10 +25,26 @@ describe('App', () => {
     expect(result).toMatchSnapshot();
   });
 
-  it('should return null in case of missing processor', () => {
+  it('should throw an error in case of missing processor', () => {
     expect(() => {
       app('some.yaml', 'no-processor');
     }).toThrowError('Missing processors for "no-processor" format');
+  });
+
+  it('should return null in case of error in processing yaml', () => {
+    yaml.safeLoad = () => {
+      throw new Error('fakeError');
+    };
+    const result = app('some.yaml', 'js');
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should return null in case of error in processing JS', () => {
+    js.compile = () => {
+      throw new Error('fakeError');
+    };
+    const result = app('some.yaml', 'js');
+    expect(result).toMatchSnapshot();
   });
 
   it('should extend processors list with list from config and use custom processors', () => {


### PR DESCRIPTION
# What does this PR do:

* On `src/app.js`, changes the `processors` variable from `let` to `const`.

* On `tests/specs/app.spec.js` adds 2 new tests, to check the cases where it should return null, and fixes a typo in a test's title.

# Where should the reviewer start:
  - Diffs

# Unit and/or functional tests:
Added 2 new test cases on the `app.js` suite.