### PR TITLE
Adds coveralls as a dependency and the task 'coverage:coveralls'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ script:
   - 'npm run lint'
   - 'npm test'
 
+after_success: 'npm run coverage:coveralls'
+
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "lib/app.js",
   "scripts": {
     "build": "babel --copy-files ./src --out-dir lib",
-    "transpile": "npm run build",
+    "coverage:coveralls": "cat ./coverage/lcov.info | $(npm bin)/../coveralls/bin/coveralls.js",
     "install": "npm run build",
     "lint": "eslint --color '{src,tests}/**/*.js'",
     "test": "jest",
-    "test:update": "jest -u"
+    "test:update": "jest -u",
+    "transpile": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -51,6 +52,7 @@
     "babel-loader": "6.2.4",
     "babel-preset-es2015": "6.16.0",
     "babel-register": "6.11.6",
+    "coveralls": "^2.11.12",
     "eslint": "3.2.2",
     "eslint-config-travix": "^1.3.0",
     "eslint-plugin-babel": "3.3.0",


### PR DESCRIPTION
# What does this PR do:

* Adds `coveralls` as a dependency and the task `coverage:coveralls` to the `package.json` which uses the coverage report generated by Jest to pass metrics to coveralls.

* Changes `.travis.yml` to run the `coverage:coveralls` after successfully run Travis CI.

You should now see coveralls comments on the PRs.

# Where should the reviewer start:
  - Diffs

# Unit and/or functional tests:
N/A