### PR TITLE
Add deep extend with default theme if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,33 @@ $ui-button-color-bg: #1fcff6;
 ```
 
 You can save the output to `.scss` file and use while writing your styles.
+
+## API (Types)
+
+```jsx
+function themeBuilder(
+  // Path to main theme YAML file
+  themeYaml: string,
+
+  // Output format
+  format: string,
+
+  // Optional config
+  config?: Config
+): any
+
+type Config = {
+  // Processors for additional formats
+  processors?: {[name: string]: Processor},
+
+  // Default theme YAML filepath, will be used as base to extend main YAML
+  defaultThemeYaml?: string,
+
+  // Output unit prefixes, eg. SCSS variables names prefixes
+  prefix?: string,
+}
+
+type Processor = {
+  compile(obj: object): any
+}
+```

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "webpack": "^1.13.3"
   },
   "dependencies": {
+    "deep-extend": "^0.4.1",
     "js-yaml": "^3.7.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
 /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
+const deepExtend = require('deep-extend');
 const yaml = require('js-yaml');
 const js = require('./processors/js');
 const scss = require('./processors/scss');
@@ -16,7 +17,13 @@ module.exports = function app(themeYaml, format, config = {}) {
   }
 
   try {
-    const jsonTheme = yaml.safeLoad(themeYaml);
+    let jsonTheme = yaml.safeLoad(themeYaml);
+
+    if (config.defaultThemeYaml) {
+      const defaultJsonTheme = yaml.safeLoad(config.defaultThemeYaml);
+      jsonTheme = deepExtend({}, defaultJsonTheme, jsonTheme);
+    }
+
     return processors[format].compile(jsonTheme, config.prefix ? config.prefix : '');
   } catch (error) {
     console.warn(`Failed to process theme with ${format} format. Reason:`);

--- a/tests/specs/__snapshots__/app.spec.js.snap
+++ b/tests/specs/__snapshots__/app.spec.js.snap
@@ -16,6 +16,18 @@ Object {
 }
 `;
 
+exports[`App should process yaml file with processor and extend with default yaml 1`] = `
+Object {
+  "default": "test",
+  "do": Object {
+    "deep": "workAsWell",
+    "some": Object {
+      "string": "aaa",
+    },
+  },
+}
+`;
+
 exports[`App should process yaml file with proper processor with prefix 1`] = `
 Array [
   "$tx-do-some-string: aaa;",

--- a/tests/specs/app.spec.js
+++ b/tests/specs/app.spec.js
@@ -26,6 +26,23 @@ describe('App', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('should process yaml file with processor and extend with default yaml', () => {
+    yaml.safeLoad = (name) => {
+      if (name === '_default.yaml') {
+        return {
+          default: 'test',
+          do: {
+            deep: 'workAsWell'
+          }
+        };
+      }
+
+      return doc;
+    };
+    const result = app('some.yaml', 'js', { defaultThemeYaml: '_default.yaml' });
+    expect(result).toMatchSnapshot();
+  });
+
   it('should throw an error in case of missing processor', () => {
     expect(() => {
       app('some.yaml', 'no-processor');


### PR DESCRIPTION
## What
- Add deep extend with default theme if provided
- New dependency [deep-extend](https://www.npmjs.com/package/deep-extend)
- Extend documentation using [flowtype](https://flowtype.org/docs/quick-reference.html#primitives) syntax
- Update test
