### PR TITLE
Add CSSVars and JSFlat processors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
     "build": "babel --copy-files ./src --out-dir lib",
     "coverage:coveralls": "cat ./coverage/lcov.info | $(npm bin)/../coveralls/bin/coveralls.js",
     "lint": "eslint --color '{src,tests}/**/*.js'",
-    "test": "jest",
+    "precommit": "npm run lint",
+    "prepush": "npm run test",
     "test:update": "jest -u",
+    "test": "jest",
+    "version": "npm run build",
     "transpile": "npm run build"
   },
   "repository": {
@@ -62,6 +65,7 @@
     "eslint-plugin-babel": "^4.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.7.0",
+    "husky": "^0.13.3",
     "jest": "^19.0.1",
     "webpack": "^1.13.3"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -1,12 +1,18 @@
-const jsYaml = require('js-yaml');
-const yamlUtils = require('./yamlUtils');
-const js = require('./processors/js');
-const scss = require('./processors/scss');
 const fs = require('fs');
+const jsYaml = require('js-yaml');
+
+const yamlUtils = require('./yamlUtils');
+
+const cssvars = require('./processors/cssvars');
+const js = require('./processors/js');
+const jsflat = require('./processors/jsflat');
+const scss = require('./processors/scss');
 
 const defaultConfig = {
   processors: {
+    cssvars,
     js,
+    jsflat,
     scss
   },
   prefix: '',

--- a/src/processors/cssvars.js
+++ b/src/processors/cssvars.js
@@ -1,0 +1,26 @@
+'use strict';
+
+function recursionCompile(obj, path) {
+  const keys = Object.keys(obj);
+  let result = [];
+
+  keys.forEach((key) => {
+    if (typeof obj[key] === 'string') {
+      result.push(`\t--${path}-${key}: ${obj[key]};`);
+      return;
+    }
+
+    const children = recursionCompile(obj[key], path ? `${path}-${key}` : key);
+    result = result.concat(children);
+  });
+
+  return result.join('\n');
+}
+
+const CssVarsProcessor = {
+  compile(obj, path) {
+    return `:root {\n${recursionCompile(obj, path)}\n}`;
+  }
+};
+
+module.exports = CssVarsProcessor;

--- a/src/processors/jsflat.js
+++ b/src/processors/jsflat.js
@@ -1,0 +1,26 @@
+'use strict';
+
+function recursionCompile(obj, path) {
+  const keys = Object.keys(obj);
+  let result = [];
+
+  keys.forEach((key) => {
+    if (typeof obj[key] === 'string') {
+      result.push(`\t"${path}-${key}": "${obj[key]}"`);
+      return;
+    }
+
+    const children = recursionCompile(obj[key], path ? `${path}-${key}` : key);
+    result = result.concat(children);
+  });
+
+  return result.join(',\n');
+}
+
+const JsFlatProcessor = {
+  compile(obj, path) {
+    return JSON.parse(`{\n${recursionCompile(obj, path)}\n}`);
+  }
+};
+
+module.exports = JsFlatProcessor;

--- a/tests/specs/processors/__snapshots__/cssvars.spec.js.snap
+++ b/tests/specs/processors/__snapshots__/cssvars.spec.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CSS Variables processor should compile doc to CSS Variables format 1`] = `
+":root {
+	--do-some-string: aaa;
+	--do-some-num: 12px;
+	--do-some-color: #fff;
+}"
+`;
+
+exports[`CSS Variables processor should compile doc to CSS Variables format with prefix 1`] = `
+":root {
+	--pre-do-some-string: aaa;
+	--pre-do-some-num: 12px;
+	--pre-do-some-color: #fff;
+}"
+`;

--- a/tests/specs/processors/__snapshots__/jsflat.spec.js.snap
+++ b/tests/specs/processors/__snapshots__/jsflat.spec.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JS Flat object processor should compile doc to JS Flat object format 1`] = `
+Object {
+  "do-some-color": "#fff",
+  "do-some-num": "12px",
+  "do-some-string": "aaa",
+}
+`;
+
+exports[`JS Flat object processor should compile doc to JS Flat object format with prefix 1`] = `
+Object {
+  "pre-do-some-color": "#fff",
+  "pre-do-some-num": "12px",
+  "pre-do-some-string": "aaa",
+}
+`;

--- a/tests/specs/processors/cssvars.spec.js
+++ b/tests/specs/processors/cssvars.spec.js
@@ -1,0 +1,27 @@
+const cssvarsProcessor = require('../../../src/processors/cssvars.js');
+
+describe('CSS Variables processor', () => {
+  let doc;
+
+  beforeEach(() => {
+    doc = {
+      do: {
+        some: {
+          string: 'aaa',
+          num: '12px',
+          color: '#fff'
+        }
+      }
+    };
+  });
+
+  it('should compile doc to CSS Variables format', () => {
+    const result = cssvarsProcessor.compile(doc);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should compile doc to CSS Variables format with prefix', () => {
+    const result = cssvarsProcessor.compile(doc, 'pre');
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/tests/specs/processors/jsflat.spec.js
+++ b/tests/specs/processors/jsflat.spec.js
@@ -1,0 +1,27 @@
+const jsflatProcessor = require('../../../src/processors/jsflat.js');
+
+describe('JS Flat object processor', () => {
+  let doc;
+
+  beforeEach(() => {
+    doc = {
+      do: {
+        some: {
+          string: 'aaa',
+          num: '12px',
+          color: '#fff'
+        }
+      }
+    };
+  });
+
+  it('should compile doc to JS Flat object format', () => {
+    const result = jsflatProcessor.compile(doc);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should compile doc to JS Flat object format with prefix', () => {
+    const result = jsflatProcessor.compile(doc, 'pre');
+    expect(result).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## What
- add 2 new processors:
- - to generate CSS with [CSS Variables](https://drafts.csswg.org/css-variables/)
- - to generate JS object with flat structure (no nesting)
- add husky hooks
- - run lint on commit
- - run test on push

## Where
- diff
- generated output for processors in snapshots

## Tests
- added unit tests