### PR TITLE
Implemented variable interpolation in theme definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "js-yaml": "^3.7.0",
     "lodash.merge": "^4.6.0",
+    "lodash.template": "^4.4.0",
     "yaml-ast-parser": "0.0.31"
   }
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,4 @@
-function hexToRgb(hexStr = '') {
+function hexToRgb(hexStr) {
   const hex = hexStr.replace(/^#/, '');
   const fullHex = hex.length === 3
     ? `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`
@@ -9,7 +9,7 @@ function hexToRgb(hexStr = '') {
   return [num >> 16, num >> 8 & 255, num & 255];
 }
 
-function rgba(hexStr, opacity = 1) {
+function rgba(hexStr = '', opacity = 1) {
   const values = hexToRgb(hexStr).concat(opacity).join(', ');
   return `rgba(${values})`;
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,19 @@
+function hexToRgb(hexStr = '') {
+  const hex = hexStr.replace(/^#/, '');
+  const fullHex = hex.length === 3
+    ? `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`
+    : hex;
+
+  const num = parseInt(fullHex, 16);
+  // eslint-disable-next-line no-bitwise, no-mixed-operators
+  return [num >> 16, num >> 8 & 255, num & 255];
+}
+
+function rgba(hexStr, opacity = 1) {
+  const values = hexToRgb(hexStr).concat(opacity).join(', ');
+  return `rgba(${values})`;
+}
+
+module.exports = {
+  rgba,
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,10 @@
-function hexToRgb(hexStr) {
+/**
+ * Converts hex string into it's comma separated 0-255 values
+ * Example: rgb('#FFF') => '255, 255, 255'
+ *
+ * @param {String} Hex value in the format of #FFF or #FFFFFF
+ */
+function rgb(hexStr) {
   const hex = hexStr.replace(/^#/, '');
   const fullHex = hex.length === 3
     ? `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`
@@ -6,14 +12,21 @@ function hexToRgb(hexStr) {
 
   const num = parseInt(fullHex, 16);
   // eslint-disable-next-line no-bitwise, no-mixed-operators
-  return [num >> 16, num >> 8 & 255, num & 255];
+  return [num >> 16, num >> 8 & 255, num & 255].join(', ');
 }
 
-function rgba(hexStr = '', opacity = 1) {
-  const values = hexToRgb(hexStr).concat(opacity).join(', ');
-  return `rgba(${values})`;
+/**
+ * Converts hex string and opacity pair into a proper rgba definition
+ * Example: rgba('#FFF', 0.5) => 'rgba(255, 255, 255, 0.5)'
+ *
+ * @param {String} Hex value in the format of #FFF or #FFFFFF
+ * @param {Number} Opacity from 0 to 1
+ */
+function rgba(hexStr, opacity = 1) {
+  return `rgba(${rgb(hexStr)}, ${opacity})`;
 }
 
 module.exports = {
+  rgb,
   rgba,
 };

--- a/src/processors/cssvars.js
+++ b/src/processors/cssvars.js
@@ -1,25 +1,16 @@
-'use strict';
+const jsFlat = require('./jsflat');
 
-function recursionCompile(obj, path) {
-  const keys = Object.keys(obj);
-  let result = [];
-
-  keys.forEach((key) => {
-    if (typeof obj[key] === 'string') {
-      result.push(`\t--${path}-${key}: ${obj[key]};`);
-      return;
-    }
-
-    const children = recursionCompile(obj[key], path ? `${path}-${key}` : key);
-    result = result.concat(children);
-  });
-
-  return result.join('\n');
+function dictionaryToCssVars(obj) {
+  return [
+    ':root {',
+    ...Object.keys(obj).map(key => `\t--${key}: ${obj[key]};`),
+    '}',
+  ].join('\n');
 }
 
 const CssVarsProcessor = {
   compile(obj, path) {
-    return `:root {\n${recursionCompile(obj, path)}\n}`;
+    return dictionaryToCssVars(jsFlat.compile(obj, path));
   }
 };
 

--- a/src/processors/index.js
+++ b/src/processors/index.js
@@ -1,0 +1,11 @@
+const cssvars = require("./cssvars");
+const js = require("./js");
+const jsflat = require("./jsflat");
+const scss = require("./scss");
+
+module.exports = {
+  cssvars,
+  js,
+  jsflat,
+  scss,
+};

--- a/src/processors/js.js
+++ b/src/processors/js.js
@@ -1,14 +1,39 @@
 const template = require('lodash.template');
 
-function parseExpressions(obj) {
-  return Object.keys(obj).reduce((result, key) => {
+/**
+ * Simple check if passed argument is object or array
+ *
+ * @param {any}
+ */
+function isObject(obj) {
+  return obj === Object(obj);
+}
+
+/**
+ * Apply transform on primitive values (strings, numbers)
+ *
+ * @param {Object|Array} value
+ * @param {Object} local variables to pass into transformation
+ */
+function applyTransforms(value, obj) {
+  return template(value)(obj);
+}
+
+/**
+ * This function will walk a object tree and apply transformations on it
+ *
+ * @param {Object} obj
+ * @param {Object} the parent object
+ */
+function parseExpressions(obj, proto = null) {
+  const parsedObj = Object.create(proto || obj);
+  Object.keys(obj).forEach((key) => {
     const value = obj[key];
-    return Object.assign(result, {
-      [key]: typeof value === 'string'
-        ? template(value)(obj)
-        : parseExpressions(value)
-    });
-  }, {});
+    const fn = isObject(value) ? parseExpressions : applyTransforms;
+    parsedObj[key] = fn(value, parsedObj);
+  });
+
+  return parsedObj;
 }
 
 const JsProcessor = {

--- a/src/processors/js.js
+++ b/src/processors/js.js
@@ -1,6 +1,19 @@
+const template = require('lodash.template');
+
+function parseExpressions(obj) {
+  return Object.keys(obj).reduce((result, key) => {
+    const value = obj[key];
+    return Object.assign(result, {
+      [key]: typeof value === 'string'
+        ? template(value)(obj)
+        : parseExpressions(value)
+    });
+  }, {});
+}
+
 const JsProcessor = {
   compile(obj) {
-    return obj;
+    return parseExpressions(obj);
   }
 };
 

--- a/src/processors/js.js
+++ b/src/processors/js.js
@@ -27,7 +27,7 @@ function applyTransforms(value, obj) {
  * @param {Object} the parent object
  */
 function parseExpressions(obj, proto) {
-  const parsedObj = Object.create(proto || obj);
+  const parsedObj = Object.create(proto);
   Object.keys(obj).forEach((key) => {
     const value = obj[key];
     const fn = isObject(value) ? parseExpressions : applyTransforms;

--- a/src/processors/js.js
+++ b/src/processors/js.js
@@ -1,4 +1,5 @@
 const template = require('lodash.template');
+const helpers = require('../helpers');
 
 /**
  * Simple check if passed argument is object or array
@@ -25,7 +26,7 @@ function applyTransforms(value, obj) {
  * @param {Object} obj
  * @param {Object} the parent object
  */
-function parseExpressions(obj, proto = null) {
+function parseExpressions(obj, proto) {
   const parsedObj = Object.create(proto || obj);
   Object.keys(obj).forEach((key) => {
     const value = obj[key];
@@ -38,7 +39,7 @@ function parseExpressions(obj, proto = null) {
 
 const JsProcessor = {
   compile(obj) {
-    return parseExpressions(obj);
+    return parseExpressions(obj, helpers);
   }
 };
 

--- a/src/processors/jsflat.js
+++ b/src/processors/jsflat.js
@@ -1,25 +1,22 @@
-'use strict';
+const js = require('./js');
 
 function recursionCompile(obj, path) {
-  const keys = Object.keys(obj);
-  let result = [];
-
-  keys.forEach((key) => {
-    if (typeof obj[key] === 'string') {
-      result.push(`\t"${path}-${key}": "${obj[key]}"`);
-      return;
-    }
-
-    const children = recursionCompile(obj[key], path ? `${path}-${key}` : key);
-    result = result.concat(children);
-  });
-
-  return result.join(',\n');
+  return Object.keys(obj).reduce((result, key) => {
+    const keyAtPath = path ? `${path}-${key}` : key;
+    return Object.assign(result,
+      typeof obj[key] === 'string'
+        ? { [keyAtPath]: obj[key] }
+        : recursionCompile(obj[key], keyAtPath)
+      );
+  }, {});
 }
 
 const JsFlatProcessor = {
   compile(obj, path) {
-    return JSON.parse(`{\n${recursionCompile(obj, path)}\n}`);
+    return recursionCompile(
+      js.compile(obj),
+      path
+    );
   }
 };
 

--- a/src/processors/scss.js
+++ b/src/processors/scss.js
@@ -1,21 +1,12 @@
-'use strict';
+const jsFlat = require('./jsflat');
+
+function dictionaryToSass(obj) {
+  return Object.keys(obj).map(key => `$${key}: ${obj[key]};`).join('\n');
+}
 
 const ScssProcessor = {
-  compile: function recursionCompile(obj, path) {
-    const keys = Object.keys(obj);
-    let result = [];
-
-    keys.forEach((key) => {
-      if (typeof obj[key] === 'string') {
-        result.push(`$${path}-${key}: ${obj[key]};`);
-        return;
-      }
-
-      const children = recursionCompile(obj[key], path ? `${path}-${key}` : key);
-      result = result.concat(children);
-    });
-
-    return result.join('\n');
+  compile(obj, path) {
+    return dictionaryToSass(jsFlat.compile(obj, path));
   }
 };
 

--- a/src/yamlUtils.js
+++ b/src/yamlUtils.js
@@ -9,12 +9,7 @@ function compileJsonToYaml(yamlJson) {
 }
 
 function concatYamlData(files) {
-  return files.reduce((result, file) => {
-    const fileUpd = file.split('\n').map(line => `  ${line}`);
-    fileUpd.unshift('-');
-    result += `${fileUpd.join('\n')}\n`;
-    return result;
-  }, '');
+  return files.map(file => `- ${file.split('\n').join('\n  ')}`).join('\n');
 }
 
 function getASTValue(obj, curr = {}) {

--- a/tests/specs/app/__snapshots__/app.build.spec.js.snap
+++ b/tests/specs/app/__snapshots__/app.build.spec.js.snap
@@ -3,17 +3,20 @@
 exports[`App: build should build yaml file to scss with "tx" prefix 1`] = `
 "$tx-generic-color-accent: #1fcff6;
 $tx-button-color-bg: #1fcff6;
-$tx-button-color-width: 125px;"
+$tx-button-color-width: 125px;
+$tx-button-border-style: rgba(31, 207, 246, 0.5);"
 `;
 
 exports[`App: build should build yaml file to scss with default prefix 1`] = `
 "$generic-color-accent: #1fcff6;
 $button-color-bg: #1fcff6;
-$button-color-width: 125px;"
+$button-color-width: 125px;
+$button-border-style: rgba(31, 207, 246, 0.5);"
 `;
 
 exports[`App: build should merge yaml files and build correct scss 1`] = `
 "$tx-generic-color-accent: #283A8E;
 $tx-button-color-bg: #283A8E;
-$tx-button-color-width: 125px;"
+$tx-button-color-width: 125px;
+$tx-button-border-style: rgba(40, 58, 142, 0.5);"
 `;

--- a/tests/specs/helpers.spec.js
+++ b/tests/specs/helpers.spec.js
@@ -1,23 +1,27 @@
 import helpers from '../../src/helpers';
 
-describe('Helpers: rgba', () => {
-  it('should convert a hex color value into rgba', () => {
-    expect(helpers.rgba('#FFFFFF')).toEqual('rgba(255, 255, 255, 1)');
+describe('Helpers', () => {
+  describe('rgb', () => {
+    it('should convert a hex color value into rgba', () => {
+      expect(helpers.rgb('#FFFFFF')).toEqual('255, 255, 255');
+    });
+
+    it('should handle shorthand hex color definitions correctly', () => {
+      expect(helpers.rgb('#F00')).toEqual('255, 0, 0');
+    });
+
+    it('should handle other kinds of colors', () => {
+      expect(helpers.rgb('#99424f')).toEqual('153, 66, 79');
+    });
   });
 
-  it('should handle shorthand hex color definitions correctly', () => {
-    expect(helpers.rgba('#F00')).toEqual('rgba(255, 0, 0, 1)');
-  });
+  describe('rgba', () => {
+    it('should convert a hex color value into rgba', () => {
+      expect(helpers.rgba('#FFFFFF')).toEqual('rgba(255, 255, 255, 1)');
+    });
 
-  it('should append use passed opacity', () => {
-    expect(helpers.rgba('#00FF00', 0.5)).toEqual('rgba(0, 255, 0, 0.5)');
-  });
-
-  it('should handle other kinds of colors', () => {
-    expect(helpers.rgba('#99424f', 1)).toEqual('rgba(153, 66, 79, 1)');
-  });
-
-  it('Handles undefined color as black', () => {
-    expect(helpers.rgba(undefined, 1)).toEqual('rgba(0, 0, 0, 1)');
+    it('should append use passed opacity', () => {
+      expect(helpers.rgba('#00FF00', 0.5)).toEqual('rgba(0, 255, 0, 0.5)');
+    });
   });
 });

--- a/tests/specs/helpers.spec.js
+++ b/tests/specs/helpers.spec.js
@@ -1,0 +1,23 @@
+import helpers from '../../src/helpers';
+
+describe('Helpers: rgba', () => {
+  it('should convert a hex color value into rgba', () => {
+    expect(helpers.rgba('#FFFFFF')).toEqual('rgba(255, 255, 255, 1)');
+  });
+
+  it('should handle shorthand hex color definitions correctly', () => {
+    expect(helpers.rgba('#F00')).toEqual('rgba(255, 0, 0, 1)');
+  });
+
+  it('should append use passed opacity', () => {
+    expect(helpers.rgba('#00FF00', 0.5)).toEqual('rgba(0, 255, 0, 0.5)');
+  });
+
+  it('should handle other kinds of colors', () => {
+    expect(helpers.rgba('#99424f', 1)).toEqual('rgba(153, 66, 79, 1)');
+  });
+
+  it('Handles undefined color as black', () => {
+    expect(helpers.rgba(undefined, 1)).toEqual('rgba(0, 0, 0, 1)');
+  });
+});

--- a/tests/specs/mocks/default.yaml
+++ b/tests/specs/mocks/default.yaml
@@ -5,3 +5,5 @@ button:
   color:
     bg: *accent
     width: "125px"
+  border:
+    style: ${rgba(generic.color.accent, 0.5)}

--- a/tests/specs/processors/__snapshots__/js.spec.js.snap
+++ b/tests/specs/processors/__snapshots__/js.spec.js.snap
@@ -7,6 +7,7 @@ Object {
       "color": "#fff",
       "num": "12px",
       "string": "aaa",
+      "template": "#fffaaa",
     },
   },
 }

--- a/tests/specs/processors/js.spec.js
+++ b/tests/specs/processors/js.spec.js
@@ -7,7 +7,9 @@ describe('JS process', () => {
         some: {
           string: 'aaa',
           num: '12px',
-          color: '#fff'
+          color: '#fff',
+          // eslint-disable-next-line no-template-curly-in-string
+          template: '${color}${string}'
         }
       }
     };


### PR DESCRIPTION
Which means a YAML theme defined in the following way works now:

```
generic:
  color:
    accent: #1fcff6
  borders:
  	size: 4px
  	main: ${generic.color.accent} ${size} solid;
```

Additionally, some refactoring work has been done to prevent repetition in each processor, some code has been simplified, etc.

No breaking changes have been introduced.